### PR TITLE
Memory guide: document 128 GB ECC at 5200 MT/s

### DIFF
--- a/Docs/English/02-Ultra-Memory.md
+++ b/Docs/English/02-Ultra-Memory.md
@@ -73,7 +73,7 @@ This list shows non-official but tested compatible memory. If two DIMMs work, fo
 
 | Memory brand & model | Capacity | ECC | Pass | 2-DIMM freq | 4-DIMM freq | Native freq | Rank | Failure notes |
 |----------------------|---------:|:---:|:----:|------------:|------------:|------------:|:----:|---------------|
-| SK Hynix HMCG88AGBAA095N | 32 GB | NO | ✅ | 4400 MHz |  | 5600 MHz | 2R | |
+| SK Hynix HMCG88AGBAA095N | 32 GB | YES (SMBIOS-reported) | ✅ | 4400 MT/s | 5200 MT/s (short test) | 5600 MT/s | 2R | One 4-DIMM/128 GB system; see validation note below |
 | SAMSUNG M425R4GA3BB0-CWMOL | 32 GB | NO | ❌ | 4400 MHz |  | 5600 MHz | 2R | Burn-in test error / hang |
 | Crucial HMCG88AGBAA095N | 48 GB | NO | ✅ | 4400 MHz |  | 5600 MHz | 2R | |
 | TeamGroup TED532G4800C40-SBK | 32 GB | NO | ✅ | 4400 MHz |  | 5600 MHz | 2R | |
@@ -90,6 +90,8 @@ This list shows non-official but tested compatible memory. If two DIMMs work, fo
 | Lenovo Generic N Series | 16 GB | NO | ✅ | 4400 / 4800 MHz | 4400 MHz | 5600 MHz | 1R | |
 | Crucial CT48G56C46S5.M16C1 | 48 GB | NO | ✅ | 5200 MHz |  | 5600 MHz | 2R | |
 | Crucial CT32G56C46S5.M8B1 | 32 GB | NO | ✅ | 5600MHz |  | 5600 MHz | 1R | |
+
+**SK Hynix HMCG88AGBAA095N single-system validation note:** On one 285HX system with BIOS 1.04 and four matching 32 GB 2R modules (128 GB total), each module reported Total Width 80 bits and Data Width 64 bits, while the physical memory array reported Single-bit ECC in SMBIOS. This documents firmware-reported ECC; ECC correction was not independently tested. The modules were configured at 5200 MT/s and rated at 5600 MT/s. On Linux `7.0.14-5-pve`, a guarded `stress-ng` run used two `--vm` stressor workers, 75% of available memory, `--vm-method all`, and verification for 480 seconds. `stress-ng` reported 2 passed and 0 failed, with no MCE or RAS memory errors observed during the run. No full MemTest or long soak has been completed. Treat 4-DIMM operation at 5200 MT/s and the ECC reporting as single-system community observations, not universal guarantees.
 
 
 ### Memory Community Test Passlist
@@ -119,4 +121,3 @@ Overclocking is a DIY activity. You are responsible for any instability or data 
 | Crucial CT48G56C46S5.M16C1 | 48 GB | 4800 MHz | 5200 MHz | NO |
 | Crucial CT64G56C46S5.M16C1 | 64 GB | 4800 MHz | 5200 MHz | NO |
 | Crucial CT32G56C46S5.C8BA(Y53A) | 32 GB | Wait for test | Wait for test | NO |
-


### PR DESCRIPTION
## Summary

Updates `Docs/English/02-Ultra-Memory.md` with one MS-02 Ultra 285HX community result for four SK Hynix `HMCG88AGBAA095N` 32 GB 2R modules:

- changes the module's ECC field from `NO` to `YES (SMBIOS-reported)`
- records one 4-DIMM, 128 GB system configured at 5200 MT/s
- documents the exact short Linux qualification and its limits

## Evidence

Test system:

- MS-02 Ultra 285HX, BIOS 1.04
- 4 x SK Hynix `HMCG88AGBAA095N`, 32 GB, 2R, 5600 MT/s rated
- Linux kernel `7.0.14-5-pve`

SMBIOS reported the physical memory array as `Single-bit ECC`. All four modules reported:

```text
Total Width: 80 bits
Data Width: 64 bits
Configured Memory Speed: 5200 MT/s
```

The guarded memory qualification used two `stress-ng --vm` workers, 75% of available memory, `--vm-method all`, verification, and a 480-second duration. `stress-ng` reported 2 passed and 0 failed, with no MCE or RAS memory errors observed during the run.

## Related Linux ECC implementation

I also wrote [`edac_arl_hx`](https://github.com/zs311521/edac-arl-hx), an out-of-tree Linux EDAC driver for Arrow Lake-HX. On this same 4-DIMM, 128 GB system at 5200 MT/s, it registers both memory controllers, reports 64 GB per controller in SECDED mode, and exposes live corrected- and uncorrected-error counters (currently CE=0, UE=0). The project README also documents an independent test on Arrow Lake-S Refresh (`8086:7d1a`).

A formal mainline `ie31200_edac` change is the intended next step. No upstream patch has been submitted or accepted yet; the linux-edac discussion is waiting for Intel guidance on Arrow Lake error-log clearing and CMCI notification, which this driver keeps disabled by default.

## Limits

- No full MemTest was run.
- The 5200 MT/s soak is short.
- ECC correction was not independently injected or tested on this current 4-DIMM configuration.

The guide therefore labels ECC as SMBIOS-reported and 5200 MT/s as a short, single-system community result rather than a general compatibility guarantee.
